### PR TITLE
Fixes #44

### DIFF
--- a/templates/views/contact.hbs
+++ b/templates/views/contact.hbs
@@ -32,12 +32,11 @@
 		{{#each users}}
 			{{!-- <div class="col-xs-6 col-sm-4 col-md-3"> --}}
 				<div class="contact-user">
-					<img src="
 						{{#if image.exists}}
-							{{cloudinaryUrl image width="160" height="160" crop="fill" gravity="face"}}
+							{{{cloudinaryUrl image imageTag="true" width="160" height="160" crop="fill" gravity="face"}}}
 						{{else}}
-							/images/avatar.png
-						{{/if}}" alt="" class="">
+							<img src="/images/avatar.png" alt="" class="">
+						{{/if}}
 					<div class="contact-user-info">
 						<h3>{{name.full}}</h3>
 						{{#if title}}<p class="contact-user-title">{{title}}</p>{{/if}}

--- a/templates/views/helpers/index.js
+++ b/templates/views/helpers/index.js
@@ -205,11 +205,15 @@ module.exports = function() {
 		context = context === null ? undefined : context;
 		
 		if ((context) && (context.public_id)) {
-			var imageName = context.public_id;
+			var imageName = context.public_id, cloudinaryFn = cloudinary.url;
 			if(!options.hash || !options.hash.format){
 				imageName = imageName.concat('.', context.format);
 			}
-			return cloudinary.url(imageName, options.hash);
+			if(options.hash && options.hash.imageTag){
+				cloudinaryFn = cloudinary.image;
+				delete options.hash.imageTag;
+			}
+			return cloudinaryFn(imageName, options.hash);
 		}
 		else {
 			return null;

--- a/templates/views/index.hbs
+++ b/templates/views/index.hbs
@@ -16,7 +16,7 @@
 		{{# each data.newsWithImage}}
 		<div class="item {{#if @first }}active{{/if}}">
 			<a href="{{newsUrl slug}}">
-				<img src="{{cloudinaryUrl image width="1024" height="400" crop="fill" gravity="north"}}">
+				{{{cloudinaryUrl image imageTag="true" width="1024" height="400" crop="fill" gravity="north"}}}
 			</a>
 			<div class="carousel-caption">
 				<h2>{{{title}}}</h2>
@@ -80,7 +80,7 @@
 	{{/ifeq}}
 	{{#ifeq informationBlurb.type 'image'}}
 	<div class="caption-ct">
-		<img src="{{cloudinaryUrl informationBlurb.image width=600 height=400 crop='fill'}}" class="img-responsive">
+		{{{cloudinaryUrl informationBlurb.image imageTag="true" width=600 height=400 crop='fill' class="img-responsive"}}}
 		{{#if informationBlurb.imageText}}
 		<div class="caption-text">
 			{{informationBlurb.imageText}}

--- a/templates/views/layouts/default.hbs
+++ b/templates/views/layouts/default.hbs
@@ -54,7 +54,7 @@
 							</ul>
 							<ul class="nav navbar-nav navbar-right">
 								{{#if user}}
-								<li><a href="#" class="user"><img src="{{#if user.image.exists}}{{cloudinaryUrl user.image width="27" height="27" crop="fill"}}{{else}}/images/avatar.png{{/if}}" alt="" width="27" class="img-circle"></a></li>
+								<li><a href="#" class="user">{{#if user.image.exists}}{{{cloudinaryUrl user.image imageTag="true" class="img-circle" width="27" height="27" crop="fill"}}}{{else}}<img src="/images/avatar.png" alt="" width="27" class="img-circle">{{/if}}</a></li>
 								<li><a href="/keystone/signout">Sign Out</a></li>
 								{{else}}
 								<li><a href="/keystone/signin">Sign In</a></li>

--- a/templates/views/news.hbs
+++ b/templates/views/news.hbs
@@ -13,7 +13,7 @@
 					<div data-ks-editable="{{#if ../user}}{{adminEditableUrl ../../user "NewsItem" _id}}{{/if}}" class="news-list-item">
 						{{#if image.exists}}
 						<div class="news-list-item-image">
-								<img src="{{cloudinaryUrl image width=500 height=350 crop='fill'}}" class="">
+							{{{cloudinaryUrl image imageTag="true" width=500 height=350 crop='fill'}}}
 						</div>
 						{{/if}}
 						<div class="news-list-item-content">

--- a/templates/views/newsitem.hbs
+++ b/templates/views/newsitem.hbs
@@ -19,7 +19,7 @@
 				</div>
 			</div>
 		</div>
-		<img src="{{cloudinaryUrl image width=1400 height=600 crop='fill' gravity='faces'}}" class="news-item-main-img img-responsive">
+		{{{cloudinaryUrl image imageTag="true" width=1400 height=600 crop='fill' gravity='faces' class="news-item-main-img img-responsive"}}}
 		<div class="container">
 			<div class="row">
 				<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
@@ -33,7 +33,9 @@
 				<div class="col-sm-12">
 				<div class="news-item-author">
 					{{#with author}}
-					{{#if image.exists}}<img src="{{cloudinaryUrl image width="80" height="80" crop="fill" gravity="face"}}" alt="{{name.first}} {{name.last}}">{{/if}}
+					{{#if image.exists}}
+						{{{cloudinaryUrl image imageTag="true" width="80" height="80" crop="fill" gravity="face" alt="{{name.first}} {{name.last}}" }}}
+					{{/if}}
 					<div class="news-item-author-info">
 						<span class="news-item-name">{{name.first}} {{name.last}}</span>
 						<span class="news-item-email">{{email}}</span>

--- a/templates/views/page.hbs
+++ b/templates/views/page.hbs
@@ -45,7 +45,7 @@
 			</header>
 			{{#if image.exists}}
 			<div class="caption-ct">
-				<img src="{{cloudinaryUrl image width="750" crop="fill"}}" class="img-responsive">
+				{{{cloudinaryUrl image imageTag="true" width="750" crop="fill" class="img-responsive"}}}
 				{{#if imageDescription}}<div class="caption-text">{{imageDescription}}</div>{{/if}}
 			</div>
 			{{/if}}
@@ -80,7 +80,7 @@
 				{{else}}
 					<div class="col-sm-6 col-lg-4">
 				{{/ifeq}}
-					<a href="{{cloudinaryUrl this}}"><img src="{{cloudinaryUrl this width="500" crop="fill"}}" class="img-responsive"></a>
+					<a href="{{cloudinaryUrl this}}">{{{cloudinaryUrl this imageTag="true" width="500" crop="fill" class="img-responsive"}}}</a>
 					</div>
 			{{/each}}
 		{{/if}}

--- a/templates/views/partials/newswidget.hbs
+++ b/templates/views/partials/newswidget.hbs
@@ -2,7 +2,7 @@
 <div class="caption-ct news-widget">
 	<a href="{{newsUrl slug}}">
 	{{#if image}}
-	<img src="{{cloudinaryUrl image width="500" height="500" crop="fill"}}" alt="" class="img-responsive">
+	{{{cloudinaryUrl image imageTag="true" width="500" height="500" crop="fill" class="img-responsive"}}}
 	{{/if}}
 	<div class="caption-text news-widget-caption">
 		<h2>{{title}}</h2>

--- a/templates/views/widgets/reportlist.hbs
+++ b/templates/views/widgets/reportlist.hbs
@@ -1,10 +1,10 @@
 <div class="report-list">
 {{#each reports}}
 	<div class="col-sm-4 col-xs-12">
-		<a href="{{cloudinaryUrl pdf}}" target="_blank" class="">
+		<a href="{{cloudinaryUrl pdf secure="true"}}" target="_blank" class="">
 			<div class="report-list-report">
 				<p>{{year}}</p>
-				<img class="img-responsive" src="{{cloudinaryUrl pdf width='200' crop='fill' page='1' format='png'}}">
+				{{{cloudinaryUrl pdf imageTag="true" width="200" crop="fill" page="1" format="png" class="img-responsive"}}}
 			</div>
 		</a>
 	</div>


### PR DESCRIPTION
Cloudinary is now able to inject img-tags and should be able to refer to
https based on request page protocol. See
http://cloudinary.com/documentation/node_image_manipulation#secure_https_urls

All current instances of the cloudinary helper in hbs should now be
using `cloudinary.image` instead of `cloudinary.url`