### PR TITLE
Changes to Markdown

### DIFF
--- a/models/NewsItem.js
+++ b/models/NewsItem.js
@@ -37,7 +37,7 @@ NewsItem.add({
 	content: {
 		brief: { type: Types.Textarea, height: 150, note: 'Briefly summarize the news item in a few lines. Used to present outside context' },
 		lead: { type: Types.Textarea, height: 150, dependsOn: { newsType: 'extended' } },
-		extended: { type: Types.Markdown, height: 400, dependsOn: { newsType: 'extended' } }
+		extended: { type: Types.Markdown, height: 400, dependsOn: { newsType: 'extended' }, toolbarOptions: { hiddenButtons: 'Image,Quote,Code' } }
 	}
 	// categories: { type: Types.Relationship, ref: 'NewsItemCategory', many: true }
 });

--- a/models/Page/BasePage.js
+++ b/models/Page/BasePage.js
@@ -68,7 +68,7 @@ BasePage.add({
 		type: Types.Markdown,
 		height: 400,
 		toolbarOptions: {
-			hiddenButtons: 'H1,H6'
+			hiddenButtons: 'H1,Image,Quote,Code'
 		}
 	},
 	images: {

--- a/models/RegisterInformation.js
+++ b/models/RegisterInformation.js
@@ -15,7 +15,7 @@ var RegisterInformation = new keystone.List('RegisterInformation', {
 
 RegisterInformation.add({
 	name: { type: String, required: true },
-	description: { type: Types.Markdown, height: 300 },
+	description: { type: Types.Markdown, height: 300, toolbarOptions: { hiddenButtons: 'Image,Quote,Code' } },
 	email: { type: Types.Email },
 	// location: { type: Types.Location },
 	phone: { type: String }


### PR DESCRIPTION
Changed Markdown to remove the Image, Quote and Code buttons from the
Markdown toolbar.

The buttons for H1 and H6 were hidden in BasePage, but H6 is hidden by default so I removed that code.