### PR TITLE
Using referer to get protocol in Stratum proxy

### DIFF
--- a/routes/proxies/stratum.js
+++ b/routes/proxies/stratum.js
@@ -2,7 +2,7 @@ var request = require('request'),
 	keystone = require('keystone');
 
 exports = module.exports = function(req, res) {
-	var protocol = req.secure ? 'https://' : 'http://',
+	var protocol = req.headers['referer'].split('/')[0] + '//',
 	// Might be a good idea to have a more fail safe approach to this string concatenation.
 		stratumUrl = protocol + keystone.get('stratum server') + '/',
 		uri;


### PR DESCRIPTION
If we move the proxy handling entirely out of Keystone or can setup proxying before body-parser intercepts in the future, we kan look at some other solution. Perhaps being able to use Express's [trust proxy](http://expressjs.com/en/guide/behind-proxies.html) to manage most of this. For now, I believe this will do. It still has the benefit of never proxying unsecure request as secure requests to Stratum.
