### PR TITLE
Lowered version of to-markdown should fix the problem with node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "moment": "~2.11.1",
     "mongodb": "^2.1.4",
     "request": "^2.67.0",
-    "to-markdown": "^2.0.1",
+    "to-markdown": "^1.3.0",
     "underscore": "~1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #123