### PR TITLE
130 register styles

### DIFF
--- a/keystone.js
+++ b/keystone.js
@@ -28,6 +28,7 @@ keystone.init({
 	
 	//Gets the name of the currently active directory
 	'app name': appName,
+	'style entry': '/dist/' + (process.env.OVERRIDES_STYLES ? appName : 'app') + '.styles.css',
 	'view engine': 'hbs',
 	'custom engine': handlebars.create({
 		layoutsDir: path.join(root, 'templates/views/layouts'),

--- a/keystone.js
+++ b/keystone.js
@@ -11,6 +11,7 @@ var keystone = require('keystone'),
 	stratum = require('./' + path.join(root, 'utils/stratum')),
 	subPageCount = require('./' + path.join(root, 'utils/sub-page-count')),
 	Helpers = require('./' + path.join(root, 'templates/views/helpers')),
+	appName = process.env.ROOT ? __dirname.split(path.sep).pop() : 'app',
 	pkg = require('./' + path.join(root, 'package.json'));
 
 // Initialise Keystone with your project's configuration.
@@ -24,6 +25,9 @@ keystone.init({
 	'static': ['override', path.join(root, 'public')],
 	'favicon': path.join(root, 'public/favicon.ico'),
 	'views': path.join(root, 'templates/views'),
+	
+	//Gets the name of the currently active directory
+	'app name': appName,
 	'view engine': 'hbs',
 	'custom engine': handlebars.create({
 		layoutsDir: path.join(root, 'templates/views/layouts'),

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "envify": "^3.4.0",
     "express-handlebars": "^3.0.0",
     "font-awesome": "^4.5.0",
+    "glob": "^7.0.0",
     "handlebars": "^4.0.5",
     "isomorphic-fetch": "^2.2.1",
     "jquery": "^1.11.1",

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -46,6 +46,7 @@ exports.initLocals = function(req, res, next) {
 	locals.brand = keystone.get('brand');
 	locals.contextId = req.contextId;
 	locals.stratumUser = req.stratumUser;
+	locals.styleEntry = keystone.get('style entry');
 	locals.env = keystone.get('env');
 	async.series({
 		loadMenuBlocks: function(cb) {

--- a/templates/views/layouts/default.hbs
+++ b/templates/views/layouts/default.hbs
@@ -8,7 +8,7 @@
 		<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 		
 		{{#ifeq env "production"}}
-		<link href="/dist/styles.css" rel="stylesheet">
+		<link href="{{styleEntry}}" rel="stylesheet">
 		{{/ifeq}}
 
 		{{!-- This file provides the default styling for the KeystoneJS Content Editor
@@ -177,7 +177,7 @@
 		<script type="text/javascript" src="/js/bundle.js"></script>
 		{{else}}
 		<script type="text/javascript" src="/dist/vendors.js"></script>
-		<script type="text/javascript" src="/dist/bundle.js"></script>
+		<script type="text/javascript" src="/dist/app.bundle.js"></script>
 		{{/ifeq}}
 		{{!-- // <script type="text/javascript" src="/js/react/application.js"></script> --}}
 		<!--{{{isAdminEditorJS user}}}-->

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -2,17 +2,32 @@ var path = require('path');
 var webpack = require('webpack');
 var node_modules_dir = path.resolve(__dirname, 'node_modules');
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
+var glob = require('glob');
 
 require('dotenv').load();
 
+var jsEntry = {
+	app: path.resolve(__dirname, 'client/scripts/index.jsx'),
+	vendors: ['react', 'jquery', 'react-bootstrap', 'react-dom', 'redux']
+};
+
+function findRegisters() {
+	var registerStyles = jsEntry;
+	glob.sync('registers/*/override/styles/site.less').forEach(function (stylePath) {
+		var match = /^registers\/([^\/]+)\//.exec(stylePath);
+		if (match) {
+			registerStyles[match[1]] = path.resolve(__dirname, stylePath);
+	}
+	});
+	return registerStyles;
+}
+
+
 module.exports = {
-    entry: {
-        app: path.resolve(__dirname, 'client/scripts/index.jsx'),
-        vendors: ['react', 'jquery', 'moment', 'react-bootstrap']
-    },
+    entry: findRegisters(),
     output: {
         path: path.resolve(__dirname, 'public/dist/'),
-        filename: 'bundle.js'
+        filename: '[name].bundle.js'
     },
     plugins: [
         new webpack.DefinePlugin({
@@ -31,7 +46,7 @@ module.exports = {
 			$: "jquery",
 			jQuery: "jquery"
 		}),
-		new ExtractTextPlugin('styles.css'),
+		new ExtractTextPlugin('[name].styles.css'),
         new webpack.optimize.CommonsChunkPlugin('vendors', 'vendors.js')
     ],
     module: {


### PR DESCRIPTION
Currently working with the exception of component loaded styles. 

A more clean solution could probably be to a webpack build for each individual register with its corresponding .env-file instead of running all in a big one

Closes #130 for now