### PR TITLE
Link to pages based on a unique id

### DIFF
--- a/models/Page/BasePage.js
+++ b/models/Page/BasePage.js
@@ -150,4 +150,8 @@ BasePage.schema.virtual('extraImages').get(function(){
 	return extraImages;
 });
 
+BasePage.schema.virtual('directPath').get(function(){
+	return '/' + this.slug + '/p/' + this.shortId;
+});
+
 BasePage.register();

--- a/models/Page/BasePage.js
+++ b/models/Page/BasePage.js
@@ -1,5 +1,6 @@
 var keystone = require('keystone'),
-	Types = keystone.Field.Types;
+	Types = keystone.Field.Types,
+    shortid = require('shortid');
 
 /**
  * Base Page Model
@@ -45,6 +46,13 @@ BasePage.add({
 		type: String,
 		required: true
 	},
+    shortId: {
+        type: String,
+        'default': shortid.generate,
+        index: true,
+        unique: true,
+        noedit: true
+    },
 	menuTitle: {
 		type: String,
 		collapse: true,

--- a/models/StartPageWidget.js
+++ b/models/StartPageWidget.js
@@ -33,8 +33,7 @@ StartPageWidget.add({
 		type: Types.Relationship,
 		ref: 'BasePage',
 		index: true,
-		dependsOn: { linkType: 'page' },
-		note: 'Do not use, Not yet implemented!'
+		dependsOn: { linkType: 'page' }
 	},
 	link: {
 		type: Types.Url,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "redux-thunk": "^1.0.3",
     "request": "^2.69.0",
     "roboto-slab-fontface-kit": "^1.0.1",
+    "shortid": "^2.2.6",
     "to-markdown": "^1.3.0",
     "underscore": "^1.8.3"
   },

--- a/routes/index.js
+++ b/routes/index.js
@@ -85,7 +85,6 @@ exports = module.exports = function(app) {
 	app.get('/logout', routes.views.logout);
 	
 	// Views for dynamic routes
-	app.get('/:menublock?', routes.views.page);
-	app.get('/:menublock/*/p/:shortid', routes.views.page);
-	app.get('/:menublock?/:page', routes.views.page);
+	app.get('/:menublock/', routes.views.menublock);
+	app.get('*/p/:shortid', routes.views.page);
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -86,5 +86,6 @@ exports = module.exports = function(app) {
 	
 	// Views for dynamic routes
 	app.get('/:menublock?', routes.views.page);
+	app.get('/:menublock/*/p/:shortid', routes.views.page);
 	app.get('/:menublock?/:page', routes.views.page);
 };

--- a/routes/views/index.js
+++ b/routes/views/index.js
@@ -45,6 +45,7 @@ exports = module.exports = function(req, res) {
 			.sort('sortOrder')
 			.limit(8)
 			.populate('widget')
+			.populate('page', 'slug shortId')
 			.exec(function(err, widgets) {
 				if (!err) {
 					locals.data.startPageWidgets = widgets;
@@ -60,6 +61,9 @@ exports = module.exports = function(req, res) {
 			// Only works with KeystoneWidget for now
 			if (widget.useWidget && 
 				widget.widget && widget.widget.type === 'keystone') {
+				if(widget.linkType === 'page' && widget.page){
+					widget.link = widget.page.directPath;
+				}
 				keystone.list('KeystoneWidget').model
 					.findOne()
 					.where('_id', widget.widget.keystoneWidget)

--- a/routes/views/menublock.js
+++ b/routes/views/menublock.js
@@ -1,0 +1,67 @@
+var keystone = require('keystone'),
+	_ = require('underscore'),
+	importRoutes = keystone.importer(__dirname);
+
+exports = module.exports = function(req, res) {
+	var view = new keystone.View(req, res),
+		locals = res.locals, context = {};
+
+	locals.breadcrumbs = [];
+	locals.data = {
+		currentMenuBlock: {},
+		page: {},
+	};
+	locals.filters = {
+		menu: req.params.menublock
+	};
+		
+	/**
+	 * Look for menu blocks matching parameter
+	 */
+	view.on('init', function(next) {
+		keystone.list('MenuBlock').model
+			.findOne()
+			.where('slug', locals.filters.menu)
+			.where('static', false)
+			.exec(function(err, menu) {
+				if (err) {
+					next(err);
+				} else if (!menu) {
+					res.status(404).send('Not found');
+					return;
+				} else {
+					locals.data.currentMenuBlock = menu;
+					locals.section = menu.slug;
+					locals.breadcrumbs.push({
+						label: menu.name,
+						path: '/' + menu.slug
+					});
+					next();
+				}
+			});
+	});
+
+	/**
+	 * Find first page in menu block and redirect to found page 
+	 */
+	view.on('init', function(next) {
+		keystone.list('Page').model
+			.findOne()
+			.where('menu', locals.data.currentMenuBlock._id)
+			.sort('sortOrder')
+			.exec(function(err, page) {
+				if (!err) {
+					locals.data.page = page;
+                    if(!page){
+                        res.status(404).send('Not found');
+                    } else {
+						res.redirect('/' + locals.data.currentMenuBlock.slug + '/' + page.slug + '/p/' + page.shortId);
+					}
+				} else {
+					res.status(500).send('error');
+				}
+			});
+	});
+	
+	view.render('page');
+};

--- a/templates/views/layouts/default.hbs
+++ b/templates/views/layouts/default.hbs
@@ -55,14 +55,14 @@
                                         {{#each ../data.pages}}
                                             {{#ifeq ../../data.menuPage.slug slug}}
                                             <li class="{{#ifeq ../../data.page.slug slug}}active {{/ifeq}}{{#if this.hasSubPages}}has-sub-pages expanded{{/if}}">
-                                                <a href="/{{../../data.currentMenuBlock.slug}}/{{slug}}">{{titleForMenu}}</a>
+                                                <a href="/{{../../data.currentMenuBlock.slug}}/{{slug}}/p/{{shortId}}">{{titleForMenu}}</a>
                                             </li>
                                             {{#each ../../data.subPages}}
-                                                <li class="sub-sub-nav{{#ifeq ../../../data.page.slug slug}} active{{/ifeq}}"><a href="/{{../../../data.currentMenuBlock.slug}}/{{slug}}">{{titleForMenu}}</a></li>
+                                                <li class="sub-sub-nav{{#ifeq ../../../data.page.slug slug}} active{{/ifeq}}"><a href="/{{../../../data.currentMenuBlock.slug}}/{{slug}}/p/{{shortId}}">{{titleForMenu}}</a></li>
                                             {{/each}}
                                             {{else}}
                                             <li {{#if hasSubPages}}class="has-sub-pages"{{/if}}>
-                                                <a href="/{{../../data.currentMenuBlock.slug}}/{{slug}}">{{titleForMenu}}</a>
+                                                <a href="/{{../../data.currentMenuBlock.slug}}/{{slug}}/p/{{shortId}}">{{titleForMenu}}</a>
                                             </li>
                                             {{/ifeq}}
                                         {{/each}}

--- a/templates/views/page.hbs
+++ b/templates/views/page.hbs
@@ -29,12 +29,12 @@
 				{{#each data.pages}}
 				{{#ifeq ../data.menuPage.slug slug}}
 					<li class="{{#ifeq ../data.page.slug slug}}active {{/ifeq}}{{#if this.hasSubPages}}has-sub-pages expanded{{/if}}">
-						<a href="/{{../data.currentMenuBlock.slug}}/{{slug}}">{{titleForMenu}}</a>
+						<a href="/{{../data.currentMenuBlock.slug}}/{{slug}}/p/{{shortId}}">{{titleForMenu}}</a>
 						{{#each ../data.subPages}}
 						{{#if @first}}
 						<ul class="nav nav-pills nav-stacked nav-page-second">
 						{{/if}}
-							<li{{#ifeq ../../data.page.slug slug}} class="active"{{/ifeq}}><a href="/{{../../data.currentMenuBlock.slug}}/{{slug}}">{{titleForMenu}}</a></li>
+							<li{{#ifeq ../../data.page.slug slug}} class="active"{{/ifeq}}><a href="/{{../../data.currentMenuBlock.slug}}/{{slug}}/p/{{shortId}}">{{titleForMenu}}</a></li>
 						{{#if @last}}
 						</ul>
 						{{/if}}
@@ -42,7 +42,7 @@
 					</li>
 				{{else}}
 					<li {{#if hasSubPages}}class="has-sub-pages"{{/if}}>
-						<a href="/{{../data.currentMenuBlock.slug}}/{{slug}}">{{titleForMenu}}</a>
+						<a href="/{{../data.currentMenuBlock.slug}}/{{slug}}/p/{{shortId}}">{{titleForMenu}}</a>
 					</li>
 				{{/ifeq}}
 				{{/each}}

--- a/updates/0.0.13-generate-short-id.js
+++ b/updates/0.0.13-generate-short-id.js
@@ -1,0 +1,30 @@
+var keystone = require('keystone'),
+	async = require('async'),
+    shortid = require('shortid'),
+	BasePage = keystone.list('BasePage');
+
+//Set all instances of layout = wide and set to standard
+exports = module.exports = function (done) {
+	var context = {
+		pages: []
+	};
+
+	async.series({
+		getAllPages: function (next) {
+			BasePage.model
+				.find({shortId: {$exists: false}})
+				.exec(function (err, pages) {
+					if (!err) {
+						context.pages = pages;
+					}
+					next(err);
+				});
+		},
+		generateShortId: function (next) {
+			async.forEach(context.pages, function (page, cb) {
+				page.set('shortId', shortid.generate());
+				page.save(cb);
+			}, next);
+		}
+	}, done);
+};


### PR DESCRIPTION
* Changed all internal and external linking for Page. This will break all instances of any hard coded links which was pointing to pages before. All page linking is now based on a short id, unique for every page, on the format `/p/{shortId}`
* Added a virtual method on `directPath` BasePage for retreiving a link to the Page on the format `/{slug}/p/{shortId}`

Closes #101 
Closes #171