### PR TITLE
Even out menu blocks (modern view)

### DIFF
--- a/client/scripts/components/Menu.jsx
+++ b/client/scripts/components/Menu.jsx
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { Navbar, Nav, NavItem, NavDropdown } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { IndexLink } from 'react-router';

--- a/client/scripts/components/Menu.jsx
+++ b/client/scripts/components/Menu.jsx
@@ -4,9 +4,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { IndexLink } from 'react-router';
 import UserContext from '../containers/App';
 
-function formatMenu (menuItems, tabLayout, level = 0) {
-	const totalMenuCharacters = level === 0 && tabLayout && menuItems.reduce((p, c) => p + c.label.length, 0);
-
+function formatMenu (menuItems, level = 0) {
 	return menuItems.reduce((prev, menuItem, i, arr) => {
 		const { url, label, key, items, state } = menuItem;
 
@@ -16,13 +14,13 @@ function formatMenu (menuItems, tabLayout, level = 0) {
 		 */
 		if (level > 0 && items && items.length > 0) {
 			return prev.concat(
-				formatMenu([{ url, label, key, hasChildren: true }], tabLayout, level),
-				formatMenu(items, tabLayout, level + 1)
+				formatMenu([{ url, label, key, hasChildren: true }], level),
+				formatMenu(items, level + 1)
 			);
 		}
 		let retVal = prev.concat([
 			<LinkContainer to={`${url}`} activeClassName="active" key={key}>
-				{getLinkContents(menuItem, tabLayout, level, null, totalMenuCharacters)}
+				{getLinkContents(menuItem, level, null)}
 			</LinkContainer>,
 		]);
 
@@ -33,7 +31,7 @@ function formatMenu (menuItems, tabLayout, level = 0) {
 		if (level === 0 && items && items.length > 0) {
 			retVal.push(
 				<LinkContainer to={`${url}`} activeClassName="active" key={`${key}-desktop`}>
-					{getLinkContents({ url, label, key, state }, tabLayout, level, true, totalMenuCharacters)}
+					{getLinkContents({ url, label, key, state }, level, true)}
 				</LinkContainer>
 			);
 		}
@@ -43,9 +41,8 @@ function formatMenu (menuItems, tabLayout, level = 0) {
 	}, []);
 }
 
-function getLinkContents (item, tabLayout, level, desktop = false, totalMenuCharacters) {
+function getLinkContents (item, level, desktop = false) {
 	const { label, key, items, hasChildren = false } = item;
-	const tabWidthStyle = tabLayout && totalMenuCharacters ? { width: `${100 * label.length / totalMenuCharacters}%` } : {};
 	let classNames = level === 2 ? ['sub-sub-nav'] : [];
 
 	if (level === 0) {
@@ -54,7 +51,7 @@ function getLinkContents (item, tabLayout, level, desktop = false, totalMenuChar
 		} else if (items && items.length > 0) {
 			classNames.push('hidden-md', 'hidden-lg');
 		}
-		if ((desktop || !items) && tabLayout && totalMenuCharacters) {
+		if (desktop || !items) {
 			classNames.push('navbar-main-tab');
 		}
 	}
@@ -69,7 +66,7 @@ function getLinkContents (item, tabLayout, level, desktop = false, totalMenuChar
 		);
 	} else {
 		return (
-			<NavItem className={classNames.join(' ')} style={tabWidthStyle}>
+			<NavItem className={classNames.join(' ')}>
 				{`${label}`}
 			</NavItem>
 		);
@@ -79,7 +76,6 @@ function getLinkContents (item, tabLayout, level, desktop = false, totalMenuChar
 
 const Menu = ({
 	items,
-	tabLayout,
 }) => {
 	return (
 		<Navbar className="navbar-big navbar-big-tabbed" staticTop fluid>
@@ -98,7 +94,7 @@ const Menu = ({
 				<div className="navbar-main">
 					<div className="navbar-main-container">
 						<Nav pullLeft>
-							{formatMenu(items, tabLayout)}
+							{formatMenu(items)}
 						</Nav>
 					</div>
 				</div>
@@ -111,8 +107,6 @@ const Menu = ({
 
 };
 
-Menu.propTypes = {
-	tabLayout: PropTypes.bool,
-};
+Menu.propTypes = { };
 
 export default Menu;

--- a/client/scripts/containers/RouterApp.jsx
+++ b/client/scripts/containers/RouterApp.jsx
@@ -47,7 +47,7 @@ class App extends Component {
 		return location.pathname === '/404' ? children : (
 			<div className={`stratum-cms-${process.env.CLIENT_THEME || 'default'}`}>
 				<Messages id="message-container"/>
-				<Menu items={menuItems} tabLayout={process.env.CLIENT_THEME === 'modern'}/>
+				<Menu items={menuItems}/>
 				<MainContainer hasGrid={location.pathname !== '/'} breadcrumbs={breadcrumbs} id="keystone-main-container">
 					{children}
 				</MainContainer>

--- a/public/styles/site/navbar.less
+++ b/public/styles/site/navbar.less
@@ -318,11 +318,6 @@ img.navbar-brand-image-small{
 				line-height: @line-height-computed;
 			}
 
-			@media (max-width: @grid-float-breakpoint-max) {
-				> li.navbar-main-tab {
-					width: 100% !important;
-				}
-			}
 			// Uncollapse the nav
 			@media (min-width: @grid-float-breakpoint) {
 				float: left;
@@ -354,9 +349,11 @@ img.navbar-brand-image-small{
 				}
 				.stratum-cms-modern & {
 					width: 100%;
+					display: flex;
 					> li {
+						flex-grow: 1;
 						> a {
-							padding: @navbar-main-padding-vertical 0;
+							padding: @navbar-main-padding-vertical @gutter;
 							text-align: center;
 							margin-right: @gutter;
 							border-radius: 3px 3px 0 0;


### PR DESCRIPTION
Removed old javascript width calculation. Since flex-grow will only work
with newer browsers older browsers will display menu tabs in a left
aligned fashion, hopefully this is an ok compromise.